### PR TITLE
Fix typos

### DIFF
--- a/dl.php
+++ b/dl.php
@@ -52,7 +52,7 @@ class Dl
         $chunk = 10 * 1024 * 1024; // bytes per chunk (10 MB)
         $fh = fopen($targetFile, "rb");
         while (!feof($fh)) {
-            echo fread($handle, $chunk);
+            echo fread($fh, $chunk);
             ob_flush();  // flush output
             flush();
         }

--- a/responsive.htm
+++ b/responsive.htm
@@ -8,7 +8,7 @@
 <style>
 		.responsive {
         position: relative;
-        height:0
+        height:0;
         overflow: hidden;
     }
     .responsive iframe, object, embed {


### PR DESCRIPTION
## Summary
- fix chunk reading handle variable typo in PHP downloader
- fix CSS syntax in responsive iframe example

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684069b7f3a0832ab2346b8046ec1b6c